### PR TITLE
Run lint using python2 instead of python.

### DIFF
--- a/src/build.go
+++ b/src/build.go
@@ -312,7 +312,13 @@ func lint() error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("python", args...)
+	pycmd := "python"
+	if runtime.GOOS == "linux" {
+		// python by itself may refer to python3 or python2 depending on the distro,
+		// so invoke python2 explicitly.
+		pycmd = "python2"
+	}
+	cmd := exec.Command(pycmd, args...)
 	out, err := cmd.CombinedOutput()
 	if err != nil && len(out) == 0 {
 		return fmt.Errorf("Unable to run cpplint: %v", err)


### PR DESCRIPTION
On some distros (such as Arch Linux) `python` points to `python3` rather than `python2`. This causes issues with the `lint` command, as `cpplint.py` doesn't seem to work on Python 3.

Simply replacing `python` with `python2` won't work, as the default Windows installation doesn't have `python2.exe`, just `python.exe`, so a special case is needed.

Running plain `python` should work on macOS as well.