### PR TITLE
Add break statement for JSDIALOGTYPE_PROMPT.

### DIFF
--- a/src/browser_widget.cc
+++ b/src/browser_widget.cc
@@ -474,6 +474,7 @@ void BrowserWidget::RecreateCefWidget(const QString& url,
         } else {
           callback->Continue(true, CefString(result.toStdString()));
         }
+        break;
       }
       default:
         callback->Continue(false, "");


### PR DESCRIPTION
Building with g++ 7.2.0 fails due to fallthrough in case `JSDIALOGTYPE_PROMPT` in `browser_widget.cc`:
```
browser_widget.cc: In lambda function:
browser_widget.cc:476:9: error: this statement may fall through [-Werror=implicit-fallthrough=]
         }
         ^
browser_widget.cc:478:7: note: here
       default:
       ^~~~~~~
```
This patch adds the missing `break` statement to build without errors.